### PR TITLE
Add Fly.io deployment configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.gitignore
+README.md
+.github
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+fly.toml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Dependencies
+node_modules/
+npm-debug.log*
+
+# Environment files
+.env
+.env.local
+.env.production
+
+# Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Fly.io
+.fly/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Use official nginx alpine image
+FROM nginx:alpine
+
+# Set working directory
+WORKDIR /usr/share/nginx/html
+
+# Remove default nginx static files
+RUN rm -rf /usr/share/nginx/html/*
+
+# Copy our HTML application
+COPY index.html /usr/share/nginx/html/
+
+# Copy custom nginx configuration
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Expose port 8080 (Fly.io standard)
+EXPOSE 8080
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:8080/ || exit 1
+
+# Start nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Impfplan-Tracker
+
+Eine Progressive Web App (PWA) zum Tracking von 84-Tage Impfplänen für Katzen.
+
+## Features
+- 84-Tage Impfkalender
+- Dosisberechnung basierend auf Gewicht
+- Tägliche Erinnerungen
+- Offline-fähig (PWA)
+- Lokale Datenspeicherung
+
+## Deployment
+
+### Automatisches Deployment
+Das Repository ist für automatisches Deployment auf Fly.io konfiguriert.
+
+### Manuelles Deployment
+```bash
+fly deploy
+```
+
+### Lokale Entwicklung
+```bash
+# Mit Python
+python -m http.server 8080
+
+# Mit Node.js
+npx serve . -p 8080
+```
+
+## Technologie
+- Vanilla JavaScript
+- Tailwind CSS (CDN)
+- PWA Support
+- Nginx (Production)

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,34 @@
+# App name (wird bei fly launch automatisch gesetzt)
+app = "impfplan-tracker"
+
+# Primary region (Europa - Frankfurt)
+primary_region = "fra"
+
+# Build configuration
+[build]
+
+# HTTP service configuration
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+# Health checks
+[checks]
+  [checks.health]
+    grace_period = "10s"
+    interval = "30s"
+    method = "GET"
+    path = "/health"
+    port = 8080
+    timeout = "5s"
+    type = "http"
+
+# VM configuration
+[[vm]]
+  memory = '256mb'
+  cpu_kind = 'shared'
+  cpus = 1

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,52 @@
+server {
+    listen 8080;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Enable gzip compression
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_proxied expired no-cache no-store private must-revalidate auth;
+    gzip_types
+        text/plain
+        text/css
+        text/xml
+        text/javascript
+        application/javascript
+        application/xml+rss
+        application/json;
+
+    # PWA Support - all routes serve index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+        
+        # Cache control for HTML files
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires "0";
+    }
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Security headers
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+    add_header X-XSS-Protection "1; mode=block";
+    add_header Referrer-Policy "strict-origin-when-cross-origin";
+    
+    # CSP for security (adjust if needed)
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com; font-src 'self' data:; img-src 'self' data:; connect-src 'self';";
+
+    # Health check endpoint
+    location /health {
+        access_log off;
+        return 200 "healthy\n";
+        add_header Content-Type text/plain;
+    }
+}


### PR DESCRIPTION
## Summary
- provide Dockerfile and nginx configuration for serving the static site on Fly.io
- add Fly.io configuration file
- add ignore files and update README with deployment instructions

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686106d07b648323b45ed04af5e8d323