### PR TITLE
Add dynamic health check endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN rm -rf /usr/share/nginx/html/*
 # Copy our HTML application
 COPY index.html /usr/share/nginx/html/
 COPY sw.js /usr/share/nginx/html/
+COPY health.js /usr/share/nginx/html/
 
 # Copy custom nginx configuration
 COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/health.js
+++ b/health.js
@@ -1,0 +1,48 @@
+class HealthCheck {
+  static getStatus() {
+    const checks = {
+      timestamp: new Date().toISOString(),
+      status: 'healthy',
+      version: '1.0.0',
+      checks: {
+        localStorage: this.checkLocalStorage(),
+        notifications: this.checkNotifications(),
+        manifest: this.checkManifest()
+      }
+    };
+
+    const allHealthy = Object.values(checks.checks).every(c => c.status === 'ok');
+    checks.status = allHealthy ? 'healthy' : 'degraded';
+
+    return checks;
+  }
+
+  static checkLocalStorage() {
+    try {
+      localStorage.setItem('health-test', 'test');
+      localStorage.removeItem('health-test');
+      return { status: 'ok', message: 'localStorage available' };
+    } catch (e) {
+      return { status: 'error', message: 'localStorage not available' };
+    }
+  }
+
+  static checkNotifications() {
+    return {
+      status: 'Notification' in window ? 'ok' : 'warning',
+      message: 'Notification' in window ? 'API available' : 'API not supported'
+    };
+  }
+
+  static checkManifest() {
+    const manifestLink = document.querySelector('link[rel="manifest"]');
+    return {
+      status: manifestLink ? 'ok' : 'warning',
+      message: manifestLink ? 'Manifest loaded' : 'No manifest found'
+    };
+  }
+}
+
+if (window.location.pathname === '/health') {
+  document.body.innerHTML = `<pre>${JSON.stringify(HealthCheck.getStatus(), null, 2)}</pre>`;
+}

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <meta name="apple-mobile-web-app-title" content="Behandlungs-Tracker">
     
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="/health.js"></script>
     
     <style>
         /* Mobile optimizations */

--- a/nginx.conf
+++ b/nginx.conf
@@ -46,7 +46,7 @@ server {
     # Health check endpoint
     location /health {
         access_log off;
-        return 200 "healthy\n";
-        add_header Content-Type text/plain;
+        try_files /health.html /index.html;
+        add_header Content-Type application/json;
     }
 }


### PR DESCRIPTION
## Summary
- implement dynamic health check script
- include new script in HTML
- configure nginx to serve /health using index.html
- update Dockerfile to copy health.js

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68610df65e28832396ce9fd726be1b80