### PR TITLE
Add guided demo overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,17 @@
         .install-prompt.show {
             display: flex;
         }
+
+        .demo-highlight {
+            position: relative;
+            z-index: 45;
+            transition: all 0.3s ease;
+        }
+
+        @keyframes pulse-blue {
+            0%, 100% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.7); }
+            50% { box-shadow: 0 0 0 10px rgba(59, 130, 246, 0); }
+        }
     </style>
 </head>
 <body>
@@ -98,6 +109,16 @@
                     notificationsEnabled: false,
                     isDemo: false,
                     demoStep: 0,
+                    showDemoOverlay: false,
+                    demoSteps: [
+                        { target: 'cat-name-input', title: 'Katzenname eingeben', text: 'Hier trägst du den Namen deiner Katze ein für eine persönliche Behandlung.' },
+                        { target: 'weight-input', title: 'Gewicht erfassen', text: 'Das aktuelle Gewicht ist wichtig für die korrekte Dosisberechnung.' },
+                        { target: 'fip-type-select', title: 'Behandlungsart wählen', text: 'Je nach FIP-Form unterscheidet sich die Dosierung.' },
+                        { target: 'dose-display', title: 'Automatische Berechnung', text: 'Die App berechnet automatisch die richtige Tagesdosis.' },
+                        { target: 'reminder-section', title: 'Erinnerungen aktivieren', text: 'Lass dich täglich an die Behandlung erinnern.' },
+                        { target: 'calendar-grid', title: 'Behandlungskalender', text: 'Hier trackst du jeden Tag die Behandlung über 84 Tage.' },
+                        { target: 'progress-bar', title: 'Fortschritt verfolgen', text: 'Sieh deinen Behandlungsfortschritt auf einen Blick.' }
+                    ],
                     editingWeight: false,
                     editingDiary: '',
                     showFAQ: false,
@@ -206,18 +227,35 @@
             startDemo() {
                 this.state.isDemo = true;
                 this.state.demoStep = 0;
+                this.state.showDemoOverlay = true;
                 Object.assign(this.state, this.demoData);
                 this.render();
+                setTimeout(() => this.highlightDemoTarget(), 100);
             }
 
             nextDemoStep() {
-                this.state.demoStep++;
-                this.render();
+                if (this.state.demoStep < this.state.demoSteps.length - 1) {
+                    this.state.demoStep++;
+                    this.render();
+                    setTimeout(() => this.highlightDemoTarget(), 100);
+                } else {
+                    this.state.showDemoOverlay = false;
+                    this.render();
+                }
+            }
+
+            prevDemoStep() {
+                if (this.state.demoStep > 0) {
+                    this.state.demoStep--;
+                    this.render();
+                    setTimeout(() => this.highlightDemoTarget(), 100);
+                }
             }
 
             exitDemo() {
                 this.state.isDemo = false;
                 this.state.demoStep = 0;
+                this.state.showDemoOverlay = false;
                 this.state.catWeight = '';
                 this.state.fipType = '';
                 this.state.concentration = '';
@@ -352,6 +390,52 @@
                 `;
             }
 
+            renderDemoOverlay() {
+                if (!this.state.showDemoOverlay || !this.state.isDemo) return '';
+
+                const currentStep = this.state.demoSteps[this.state.demoStep];
+
+                return `
+                    <div class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
+                        <div class="bg-white rounded-xl max-w-md w-full p-6 relative">
+                            <button onclick="app.exitDemo()" class="absolute top-4 right-4 text-gray-500 hover:text-gray-700">✕</button>
+                            <div class="text-center mb-4">
+                                <div class="text-2xl mb-2">${currentStep.icon || '🎯'}</div>
+                                <h3 class="text-xl font-semibold text-gray-800">${currentStep.title}</h3>
+                                <p class="text-gray-600 mt-2">${currentStep.text}</p>
+                            </div>
+                            <div class="flex justify-between items-center mt-6">
+                                <div class="text-sm text-gray-500">
+                                    ${this.state.demoStep + 1} / ${this.state.demoSteps.length}
+                                </div>
+                                <div class="flex gap-2">
+                                    ${this.state.demoStep > 0 ? `<button onclick="app.prevDemoStep()" class="px-4 py-2 text-gray-600 hover:text-gray-800">Zurück</button>` : ''}
+                                    <button onclick="app.nextDemoStep()" class="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600">
+                                        ${this.state.demoStep === this.state.demoSteps.length - 1 ? 'Fertig' : 'Weiter'}
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                `;
+            }
+
+            highlightDemoTarget() {
+                document.querySelectorAll('.demo-highlight').forEach(el => {
+                    el.classList.remove('demo-highlight', 'ring-4', 'ring-blue-400', 'ring-opacity-75');
+                });
+
+                if (!this.state.showDemoOverlay || !this.state.isDemo) return;
+
+                const currentStep = this.state.demoSteps[this.state.demoStep];
+                const target = document.querySelector(`[data-demo="${currentStep.target}"]`);
+
+                if (target) {
+                    target.classList.add('demo-highlight', 'ring-4', 'ring-blue-400', 'ring-opacity-75');
+                    target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                }
+            }
+
             render() {
                 const dailyDose = this.state.customDose ? parseFloat(this.state.customDose) : this.calculateDose();
                 const treatmentDays = this.state.startDate ? this.generateTreatmentDays(this.state.startDate) : [];
@@ -380,6 +464,7 @@
 
                 document.getElementById('app').innerHTML = `
                     ${this.state.showFAQ ? this.renderFAQ() : ''}
+                    ${this.renderDemoOverlay()}
                     
                     <div class="max-w-4xl mx-auto p-4 md:p-6 bg-gradient-to-br from-blue-50 to-purple-50 min-h-screen">
                         <div class="bg-white rounded-xl shadow-lg mobile-compact md:p-6 mb-6">
@@ -435,23 +520,23 @@
                                                 <label class="block text-sm font-medium text-gray-700 mb-2">
                                                     🐱 Name der Katze
                                                 </label>
-                                                <input type="text" value="${this.state.catName}" 
+                                                <input data-demo="cat-name-input" type="text" value="${this.state.catName}"
                                                     onchange="app.updateState('catName', this.value)"
-                                                    class="w-full border border-gray-300 rounded-md px-3 py-2 mobile-input" 
+                                                    class="w-full border border-gray-300 rounded-md px-3 py-2 mobile-input"
                                                     placeholder="z.B. Mimi">
                                             </div>
                                             <div>
                                                 <label class="block text-sm font-medium text-gray-700 mb-2">
                                                     Gewicht der Katze (kg)
                                                 </label>
-                                                <input type="number" step="0.1" value="${this.state.catWeight}" 
+                                                <input data-demo="weight-input" type="number" step="0.1" value="${this.state.catWeight}"
                                                     onchange="app.updateState('catWeight', this.value)"
                                                     class="w-full border border-gray-300 rounded-md px-3 py-2 mobile-input" placeholder="z.B. 3.7">
                                             </div>
 
                                             <div>
                                                 <label class="block text-sm font-medium text-gray-700 mb-2">Behandlungsart</label>
-                                                <select value="${this.state.fipType}" onchange="app.updateState('fipType', this.value)"
+                                                <select data-demo="fip-type-select" value="${this.state.fipType}" onchange="app.updateState('fipType', this.value)"
                                                     class="w-full border border-gray-300 rounded-md px-3 py-2 mobile-input">
                                                     <option value="">Wählen...</option>
                                                     <option value="neuro" ${this.state.fipType === 'neuro' ? 'selected' : ''}>Neurologisch (10 mg/kg)</option>
@@ -478,7 +563,7 @@
                                         </div>
 
                                         ${dailyDose ? `
-                                            <div class="bg-green-50 border border-green-200 rounded-lg p-4">
+                                            <div data-demo="dose-display" class="bg-green-50 border border-green-200 rounded-lg p-4">
                                                 <div class="flex items-center gap-3">
                                                     <svg class="text-green-600 w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
                                                         <path d="M9 11H7v2h2v-2zm4 0h-2v2h2v-2zm4 0h-2v2h2v-2zm2-7h-1V2h-2v2H8V2H6v2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V9h14v11z"/>
@@ -550,7 +635,7 @@
                                 </div>
 
                                 <!-- Reminder Settings -->
-                                <div class="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-6">
+                                <div data-demo="reminder-section" class="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-6">
                                     <div class="flex flex-col md:flex-row md:items-center justify-between gap-4">
                                         <div class="flex items-center gap-3">
                                             <svg class="text-yellow-600 w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
@@ -577,7 +662,7 @@
                                 </div>
 
                                 <!-- Progress Overview -->
-                                <div class="bg-gradient-to-r from-green-50 to-blue-50 rounded-lg p-6 mb-6">
+                                <div data-demo="progress-bar" class="bg-gradient-to-r from-green-50 to-blue-50 rounded-lg p-6 mb-6">
                                     <h2 class="text-xl font-semibold text-gray-800 mb-4">
                                         ${this.state.catName ? `${this.state.catName}s ` : ''}Behandlungsfortschritt
                                     </h2>
@@ -688,7 +773,7 @@
                                 <!-- Treatment Calendar -->
                                 <div class="bg-white rounded-lg border border-gray-200 p-4">
                                     <h2 class="text-xl font-semibold text-gray-800 mb-4">Behandlungskalender</h2>
-                                    <div class="grid grid-cols-5 sm:grid-cols-7 gap-2 max-h-96 overflow-y-auto">
+                                    <div data-demo="calendar-grid" class="grid grid-cols-5 sm:grid-cols-7 gap-2 max-h-96 overflow-y-auto">
                                         ${treatmentDays.map((day) => {
                                             const isToday = day.date === today;
                                             const isPast = day.dateObj < new Date();
@@ -744,6 +829,7 @@
                         </div>
                     </div>
                 `;
+                setTimeout(() => this.highlightDemoTarget(), 50);
             }
 
             resetApp() {


### PR DESCRIPTION
## Summary
- expand demo state with overlay steps
- implement overlay rendering and target highlighting
- add demo controls (start, next, prev, exit)
- add data-demo attributes for guided tour elements
- highlight current tour element after rendering
- include basic demo highlight styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68611584191c8323aedaa0c684627fd7