### PR TITLE
Enable dismissible motivation cards with confetti

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
     
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="/health.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
     
     <style>
         /* Mobile optimizations */
@@ -163,7 +164,8 @@
                     editingWeight: false,
                     editingDiary: '',
                     showFAQ: false,
-                    currentTime: new Date()
+                    currentTime: new Date(),
+                    dismissedCards: {}
                 };
                 
                 this.demoData = {
@@ -470,12 +472,14 @@
             }
 
             renderSupportMessage() {
+                if (this.state.dismissedCards.support) return '';
+
                 const hardDays = [10, 20, 30, 40, 50, 60];
                 const currentDay = Object.values(this.state.treatmentData).filter(Boolean).length;
 
                 if (hardDays.includes(currentDay)) {
                     return `
-                      <div class="bg-indigo-50 border border-indigo-200 rounded-lg p-4 mb-4">
+                      <div data-card-id="support" class="bg-indigo-50 border border-indigo-200 rounded-lg p-4 mb-4">
                         <div class="flex items-center gap-3">
                           <svg class="text-indigo-600 w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
                             <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
@@ -515,6 +519,27 @@
                     }
                 }
                 return streak;
+            }
+
+            launchConfetti(el) {
+                const { left, top, width, height } = el.getBoundingClientRect();
+                const x = (left + width / 2) / window.innerWidth;
+                const y = (top + height / 2) / window.innerHeight;
+
+                confetti({
+                    particleCount: 100,
+                    spread: 70,
+                    startVelocity: 30,
+                    angle: 90,
+                    origin: { x, y },
+                    disableForReducedMotion: true,
+                });
+            }
+
+            dismissCard(id, el) {
+                this.launchConfetti(el);
+                this.state.dismissedCards[id] = true;
+                this.render();
             }
 
             render() {
@@ -764,7 +789,8 @@
                                         ${Math.round(progressPercentage)}% abgeschlossen • ${84 - completedCount} Tage verbleibend
                                     </p>
 
-                                    <div class="bg-gradient-to-r from-pink-50 to-purple-50 border border-pink-200 rounded-lg p-4 mb-6">
+                                    ${!this.state.dismissedCards.motivational ? `
+                                    <div data-card-id="motivational" class="bg-gradient-to-r from-pink-50 to-purple-50 border border-pink-200 rounded-lg p-4 mb-6">
                                         <div class="flex items-center gap-3">
                                             <div class="text-2xl">${motivationalMessage.icon}</div>
                                             <div class="flex-1">
@@ -777,11 +803,12 @@
                                             </div>
                                         </div>
                                     </div>
+                                    ` : ''}
 
                                     ${this.renderSupportMessage()}
 
-                                    ${upcomingMilestone ? `
-                                        <div class="bg-amber-50 border border-amber-200 rounded-lg p-3">
+                                    ${upcomingMilestone && !this.state.dismissedCards.milestone ? `
+                                        <div data-card-id="milestone" class="bg-amber-50 border border-amber-200 rounded-lg p-3">
                                             <div class="flex items-center gap-2">
                                                 <svg class="text-amber-600 w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
                                                     <path d="M9 11H7v2h2v-2zm4 0h-2v2h2v-2zm4 0h-2v2h2v-2zm2-7h-1V2h-2v2H8V2H6v2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V9h14v11z"/>
@@ -794,7 +821,8 @@
                                         </div>
                                     ` : ''}
 
-                                    <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 mt-4">
+                                    ${!this.state.dismissedCards.healing ? `
+                                    <div data-card-id="healing" class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 mt-4">
                                       <div class="text-center">
                                         <div class="text-emerald-700 text-sm font-medium mb-1">
                                           💚 Die Erkrankung ist heilbar!
@@ -804,6 +832,7 @@
                                         </div>
                                       </div>
                                     </div>
+                                    ` : ''}
                                 </div>
 
                                 ${todayStatus ? `
@@ -963,7 +992,9 @@
                 localStorage.removeItem('treatment-reminderTime');
                 localStorage.removeItem('treatment-progress');
                 localStorage.removeItem('treatment-diary');
-                
+
+                this.state.dismissedCards = {};
+
                 this.render();
             }
         }
@@ -974,6 +1005,11 @@
         document.addEventListener('click', (e) => {
           if (e.target.closest('.install-app-btn')) {
             installer.installApp();
+          }
+          const card = e.target.closest('[data-card-id]');
+          if (card) {
+            const id = card.getAttribute('data-card-id');
+            app.dismissCard(id, card);
           }
         });
     </script>


### PR DESCRIPTION
## Summary
- allow clicking on motivation cards to dismiss them
- add confetti effect on dismiss
- reset dismissed cards on app reset
- load canvas-confetti library

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68612fd820ac83238b1c3967c3646b0e