### PR TITLE
Add FAQ sidebar with accordion

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,22 @@
             0%, 100% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.7); }
             50% { box-shadow: 0 0 0 10px rgba(59, 130, 246, 0); }
         }
+
+        .faq-enter {
+            transform: translateX(100%);
+        }
+
+        .faq-enter-active {
+            transform: translateX(0);
+            transition: transform 300ms ease-in-out;
+        }
+
+        @media (max-width: 640px) {
+            .faq-sidebar {
+                width: 100vw;
+                max-width: none;
+            }
+        }
     </style>
 </head>
 <body>
@@ -164,6 +180,7 @@
                     editingWeight: false,
                     editingDiary: '',
                     showFAQ: false,
+                    openFAQ: null,
                     currentTime: new Date(),
                     dismissedCards: {}
                 };
@@ -314,6 +331,11 @@
                 this.render();
             }
 
+            toggleFAQ(index) {
+                this.state.openFAQ = this.state.openFAQ === index ? null : index;
+                this.render();
+            }
+
             updateDiary(date, note) {
                 this.state.diary[date] = note;
                 this.saveProgress();
@@ -373,24 +395,52 @@
                 ];
 
                 return `
-                    <div class="fixed inset-0 bg-black bg-opacity-50 flex items-start justify-center z-50 p-4 pt-8 overflow-y-auto">
-                        <div class="bg-white rounded-xl max-w-2xl w-full max-h-[85vh] overflow-hidden flex flex-col">
-                            <div class="p-6 border-b border-gray-200 flex-shrink-0">
-                                <div class="flex justify-between items-center">
-                                    <h2 class="text-2xl font-bold text-gray-800">FAQ - Häufige Fragen</h2>
-                                    <button onclick="app.updateState('showFAQ', false)" class="text-gray-500 hover:text-gray-700 text-xl p-2">
-                                        ✕
-                                    </button>
-                                </div>
-                            </div>
-                            
-                            <div class="p-6 space-y-6 overflow-y-auto flex-1">
-                                ${faqs.map((faq, index) => `
-                                    <div class="border-b border-gray-100 pb-4">
-                                        <h3 class="font-semibold text-gray-800 mb-3">${faq.question}</h3>
-                                        <p class="text-gray-600">${faq.answer}</p>
+                    <div class="fixed inset-0 z-50 flex">
+                        <div class="fixed inset-0 bg-black bg-opacity-30 transition-opacity" onclick="app.updateState('showFAQ', false)"></div>
+                        <div class="ml-auto relative">
+                            <div class="h-full w-screen max-w-md md:max-w-lg bg-white shadow-2xl transform transition-transform duration-300 ease-in-out flex flex-col overflow-hidden faq-sidebar faq-enter faq-enter-active" role="dialog" aria-labelledby="faq-title" aria-modal="true">
+                                <div class="p-4 md:p-6 border-b border-gray-200 flex-shrink-0 bg-gradient-to-r from-blue-50 to-purple-50">
+                                    <div class="flex justify-between items-center">
+                                        <div class="flex items-center gap-3">
+                                            <svg class="text-blue-600 w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+                                                <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-5 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z"/>
+                                            </svg>
+                                            <h2 id="faq-title" class="text-xl md:text-2xl font-bold text-gray-800">FAQ</h2>
+                                        </div>
+                                        <button onclick="app.updateState('showFAQ', false)" onkeydown="if(event.key==='Escape') app.updateState('showFAQ', false)" class="text-gray-500 hover:text-gray-700 text-xl p-2 rounded-full hover:bg-gray-100 transition-colors">
+                                            ✕
+                                        </button>
                                     </div>
-                                `).join('')}
+                                    <p class="text-sm text-gray-600 mt-1">Häufige Fragen zur Behandlung</p>
+                                </div>
+                                <div class="flex-1 overflow-y-auto p-4 md:p-6">
+                                    <div class="space-y-6">
+                                        ${faqs.map((faq, index) => `
+                                            <div class="border-b border-gray-100 pb-4 last:border-b-0">
+                                                <button onclick="app.toggleFAQ(${index})" class="w-full text-left focus:outline-none group">
+                                                    <div class="flex justify-between items-start gap-3">
+                                                        <h3 class="font-semibold text-gray-800 group-hover:text-blue-600 transition-colors">
+                                                            ${faq.question}
+                                                        </h3>
+                                                        <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-600 transition-transform duration-200 flex-shrink-0 mt-0.5 ${this.state.openFAQ === index ? 'rotate-180' : ''}" fill="currentColor" viewBox="0 0 24 24">
+                                                            <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"/>
+                                                        </svg>
+                                                    </div>
+                                                </button>
+                                                <div class="mt-3 transition-all duration-200 overflow-hidden ${this.state.openFAQ === index ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'}">
+                                                    <p class="text-gray-600 leading-relaxed pl-2 border-l-2 border-blue-100">
+                                                        ${faq.answer}
+                                                    </p>
+                                                </div>
+                                            </div>
+                                        `).join('')}
+                                    </div>
+                                </div>
+                                <div class="p-4 border-t border-gray-200 bg-gray-50 flex-shrink-0">
+                                    <div class="text-center">
+                                        <p class="text-xs text-gray-500">💡 Bei weiteren Fragen kontaktiere deinen Admin</p>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- implement FAQ as a sidebar panel instead of a centered modal
- add accordion behaviour for FAQ items
- include mobile styling and slide-in animation
- store open FAQ index in state

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68613506e0208323b60221cadff574da