### PR TITLE
Add interactive hints for dismissible cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,41 @@
                 max-width: none;
             }
         }
+
+        .dismissible-card {
+            cursor: pointer;
+            transition: all 0.2s ease;
+            position: relative;
+            animation: gentle-pulse 3s infinite;
+        }
+
+        .dismissible-card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+        }
+
+        .dismissible-card::after {
+            content: "✨";
+            position: absolute;
+            top: 8px;
+            right: 12px;
+            font-size: 16px;
+            opacity: 0;
+            transition: opacity 0.2s ease;
+        }
+
+        .dismissible-card:hover::after {
+            opacity: 0.6;
+        }
+
+        @keyframes gentle-pulse {
+            0%, 100% {
+                box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.1);
+            }
+            50% {
+                box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.05);
+            }
+        }
     </style>
 </head>
 <body>
@@ -529,7 +564,12 @@
 
                 if (hardDays.includes(currentDay)) {
                     return `
-                      <div data-card-id="support" class="bg-indigo-50 border border-indigo-200 rounded-lg p-4 mb-4">
+                      <div data-card-id="support" class="dismissible-card bg-indigo-50 border border-indigo-200 rounded-lg p-4 mb-4 group relative" role="button" tabindex="0" aria-label="Support Message - Klicken zum Ausblenden" onkeydown="if(event.key==='Enter'||event.key===' ') this.click()">
+                        <div class="absolute top-2 right-2 opacity-0 group-hover:opacity-50 transition-all duration-200">
+                          <svg class="w-4 h-4 text-gray-400" fill="currentColor" viewBox="0 0 24 24">
+                            <path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"/>
+                          </svg>
+                        </div>
                         <div class="flex items-center gap-3">
                           <svg class="text-indigo-600 w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
                             <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
@@ -840,7 +880,13 @@
                                     </p>
 
                                     ${!this.state.dismissedCards.motivational ? `
-                                    <div data-card-id="motivational" class="bg-gradient-to-r from-pink-50 to-purple-50 border border-pink-200 rounded-lg p-4 mb-6">
+                                    <div data-card-id="motivational" class="dismissible-card bg-gradient-to-r from-pink-50 to-purple-50 border border-pink-200 rounded-lg p-4 mb-6 group" role="button" tabindex="0" aria-label="Motivations-Karte - Klicken für Celebration" onkeydown="if(event.key==='Enter'||event.key===' ') this.click()">
+                                        <div class="absolute top-2 right-2 opacity-0 group-hover:opacity-60 transition-opacity duration-200 pointer-events-none">
+                                            <div class="flex items-center gap-1 text-xs text-gray-500 bg-white bg-opacity-80 rounded-full px-2 py-1">
+                                                <span>✨</span>
+                                                <span>Klicken</span>
+                                            </div>
+                                        </div>
                                         <div class="flex items-center gap-3">
                                             <div class="text-2xl">${motivationalMessage.icon}</div>
                                             <div class="flex-1">
@@ -848,7 +894,7 @@
                                                     ${motivationalMessage.text}
                                                 </p>
                                                 <p class="text-xs text-gray-600">
-                                                    ✨ Jede Spritze ist ein Schritt zur Heilung • 💝 Du rettest ein Leben • 🔥 Streak: ${streak} Tage
+                                                    ✨ Jede Spritze ist ein Schritt zur Heilung • 💕 Du rettest ein Leben • 🔥 Streak: ${streak} Tage
                                                 </p>
                                             </div>
                                         </div>
@@ -858,13 +904,18 @@
                                     ${this.renderSupportMessage()}
 
                                     ${upcomingMilestone && !this.state.dismissedCards.milestone ? `
-                                        <div data-card-id="milestone" class="bg-amber-50 border border-amber-200 rounded-lg p-3">
+                                        <div data-card-id="milestone" class="dismissible-card bg-amber-50 border border-amber-200 rounded-lg p-3 group relative" role="button" tabindex="0" aria-label="Meilenstein-Karte - Klicken zum Ausblenden" onkeydown="if(event.key==='Enter'||event.key===' ') this.click()">
+                                            <div class="absolute top-1 right-1 opacity-0 group-hover:opacity-70 transition-opacity duration-200">
+                                                <div class="text-xs bg-white bg-opacity-90 rounded-full w-6 h-6 flex items-center justify-center">
+                                                    🎉
+                                                </div>
+                                            </div>
                                             <div class="flex items-center gap-2">
                                                 <svg class="text-amber-600 w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
                                                     <path d="M9 11H7v2h2v-2zm4 0h-2v2h2v-2zm4 0h-2v2h2v-2zm2-7h-1V2h-2v2H8V2H6v2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V9h14v11z"/>
                                                 </svg>
                                                 <p class="text-sm font-medium text-amber-800">
-                                                    Nächster Meilenstein: ${upcomingMilestone.isMilestone.icon} ${upcomingMilestone.isMilestone.text} 
+                                                    Nächster Meilenstein: ${upcomingMilestone.isMilestone.icon} ${upcomingMilestone.isMilestone.text}
                                                     <span class="font-bold">(Tag ${upcomingMilestone.day}, in ${this.getMilestoneCountdown(upcomingMilestone, today)} Tagen)</span>
                                                 </p>
                                             </div>
@@ -872,7 +923,10 @@
                                     ` : ''}
 
                                     ${!this.state.dismissedCards.healing ? `
-                                    <div data-card-id="healing" class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 mt-4">
+                                    <div data-card-id="healing" class="dismissible-card bg-emerald-50 border border-emerald-200 rounded-lg p-3 mt-4 group relative" role="button" tabindex="0" aria-label="Heilungs-Karte - Klicken zum Ausblenden" onkeydown="if(event.key==='Enter'||event.key===' ') this.click()">
+                                      <div class="absolute top-1 right-1 opacity-0 group-hover:opacity-60 transition-opacity duration-200">
+                                        <span class="text-sm">💚</span>
+                                      </div>
                                       <div class="text-center">
                                         <div class="text-emerald-700 text-sm font-medium mb-1">
                                           💚 Die Erkrankung ist heilbar!


### PR DESCRIPTION
## Summary
- make motivational, milestone, healing and support cards keyboard accessible
- add hover hint CSS plus gentle pulse animation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861362a4d0c832391d04b8c6ab80c56