### PR TITLE
Fix loader persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -532,6 +532,8 @@
                 this.state.customDose = '';
                 this.state.treatmentData = {};
                 this.state.diary = {};
+                this.state.showLoader = false;
+                this.state.loadingComplete = true;
                 this.render();
             }
 
@@ -1448,6 +1450,9 @@
                 localStorage.removeItem('treatment-diary');
 
                 this.state.dismissedCards = {};
+
+                this.state.showLoader = false;
+                this.state.loadingComplete = true;
 
                 this.render();
             }


### PR DESCRIPTION
## Summary
- ensure loader does not reappear after reset
- keep loading state disabled after demo exit

## Testing
- `git status --short`
- `grep -n "showLoader = false" -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_68613bf3eae08323b29137e1fb21c788