### PR TITLE
Fix FAQ sidebar rendering bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -532,6 +532,8 @@
             }
 
             renderFAQ() {
+                if (!this.state.showFAQ) return '';
+
                 const faqs = [
                     {
                         question: "Welche Medikamente können parallel gegeben werden?",
@@ -609,7 +611,6 @@
                             </div>
                         </div>
                     </div>
-                    ` : ''}
                 `;
             }
 


### PR DESCRIPTION
## Summary
- correct `renderFAQ` logic in `index.html`
- remove stray ternary from return value
- add early return when FAQ overlay hidden

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68614250c13c8323a3f21f7e69e0ca5d