### PR TITLE
Add version display and improve PWA updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ npx serve . -p 8080
 - Tailwind CSS (CDN)
 - PWA Support
 - Nginx (Production)
+
+## Versions
+
+Die aktuelle Version wird im Footer angezeigt und ist ebenfalls Bestandteil des
+Service-Worker Cache-Namens. Bei jedem Deployment sollte diese Versionsnummer
+inkrementiert werden, damit installierte PWAs stets die neueste Version laden.

--- a/index.html
+++ b/index.html
@@ -1571,5 +1571,8 @@
       });
     }
     </script>
+    <footer class="text-center text-sm text-gray-500 mt-4">
+      Version 1.0.20250629165820
+    </footer>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,5 @@
-const CACHE_NAME = 'behandlung-tracker-v2';
+const VERSION = '1.0.20250629165820';
+const CACHE_NAME = `behandlung-tracker-${VERSION}`;
 const urlsToCache = [
   '/',
   '/index.html',
@@ -6,21 +7,36 @@ const urlsToCache = [
 ];
 
 self.addEventListener('install', (event) => {
+  self.skipWaiting();
   event.waitUntil(
     caches.open(CACHE_NAME)
       .then((cache) => cache.addAll(urlsToCache))
   );
 });
 
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.filter((key) => key !== CACHE_NAME)
+        .map((key) => caches.delete(key))
+    )).then(() => self.clients.claim())
+  );
+});
 self.addEventListener('fetch', (event) => {
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request)
+        .then((response) => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          return response;
+        })
+        .catch(() => caches.match(event.request))
+    );
+    return;
+  }
   event.respondWith(
     caches.match(event.request)
-      .then((response) => {
-        if (response) {
-          return response;
-        }
-        return fetch(event.request);
-      }
-    )
+      .then((response) => response || fetch(event.request))
   );
 });


### PR DESCRIPTION
## Summary
- display version number in footer
- document versioning in README
- change service worker to use versioned cache and update strategy

## Testing
- `npx -y serve -v | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_6861706897588323bd66fb413272f19e